### PR TITLE
Reset built-in controller after disconnect

### DIFF
--- a/deckpad.sh
+++ b/deckpad.sh
@@ -36,7 +36,12 @@ function run_as_root() {
     reenable_sleep
     stop_virtualhere
     reset_controller
+<<<<<<< HEAD
     wait quit_prompt_pid
+=======
+    wait $quit_prompt_pid
+    trap - EXIT
+>>>>>>> 9d44ff1 (Small bugfix)
 }
 
 source ./functions.sh

--- a/deckpad.sh
+++ b/deckpad.sh
@@ -21,6 +21,7 @@ function run_as_root() {
     # Start
     set_brightness_to_minimum
     disable_sleep
+    find_controller
     start_virtualhere
 
     # Run - Block until Tap on screen
@@ -34,6 +35,7 @@ function run_as_root() {
     restore_brightness
     reenable_sleep
     stop_virtualhere
+    reset_controller
     wait quit_prompt_pid
 }
 

--- a/deckpad.sh
+++ b/deckpad.sh
@@ -36,12 +36,7 @@ function run_as_root() {
     reenable_sleep
     stop_virtualhere
     reset_controller
-<<<<<<< HEAD
-    wait quit_prompt_pid
-=======
     wait $quit_prompt_pid
-    trap - EXIT
->>>>>>> 9d44ff1 (Small bugfix)
 }
 
 source ./functions.sh


### PR DESCRIPTION
The built-in controller doesn't always work after disconnecting from a Virtualhere client, Reset the xhci driver for the usb hub connected to the built-in controller after disconnect.